### PR TITLE
Add custom error type support for tpm run function

### DIFF
--- a/src/secure_mount.rs
+++ b/src/secure_mount.rs
@@ -1,10 +1,10 @@
 use super::*;
 
 use common::emsg;
+use std::error::Error;
 use std::fs;
 use std::os::unix::fs::PermissionsExt;
 use std::process::Command;
-
 /*
  * Input: secure mount directory
  * Return: Result wrap boolean with error message
@@ -122,7 +122,7 @@ fn mount() -> Result<String, Box<String>> {
                         })?;
 
                     // mount tmpfs with secure directory
-                    if let Err(e) = tpm::run(
+                    tpm::run(
                         format!(
                             "mount -t tmpfs -o size={},mode=0700 tmpfs {}",
                             common::SECURE_SIZE,
@@ -130,16 +130,8 @@ fn mount() -> Result<String, Box<String>> {
                         ),
                         tpm::EXIT_SUCCESS,
                         None,
-                    ) {
-                        error!(
-                            "Failed to execute mount command with error {}.",
-                            e
-                        );
-                        return emsg(
-                            "Failed to mount secure directory tmpfs.",
-                            None::<String>,
-                        );
-                    }
+                    )
+                    .map_err(|e| e.description().to_string())?;
 
                     Ok(s.to_string())
                 }


### PR DESCRIPTION
1. Implement From trait for Error:
       std::string::FromUtf8Error
       std::io::Error
       std::time::SystemTimeError

2. Change return type of run() function in a tuple and a custom error
       Result<(String, String), TpmExecError>

3. Move return code to custom error type, with return code 10 stand for
   error during the execution of run() function and the other error code
   stand for error code return from TPM command execution